### PR TITLE
Fix initial load

### DIFF
--- a/streamlit_url_fragment/src/index.ts
+++ b/streamlit_url_fragment/src/index.ts
@@ -8,5 +8,5 @@ const hashChangeHandler = () => {
 
 targetWindow.addEventListener('hashchange', hashChangeHandler)
 Streamlit.setComponentReady()
-hashChangeHandler()
+Streamlit.events.addEventListener(Streamlit.RENDER_EVENT, hashChangeHandler)
 Streamlit.setFrameHeight(0)


### PR DESCRIPTION
Streamlit 1.32 break this component on first page load 

https://github.com/streamlit/streamlit/issues/8387 

Just call the when the handler on Streamlit.RENDER_EVENT